### PR TITLE
Fix #60: Patch structural cursor desynchronization: use DictCursor

### DIFF
--- a/server/app/routes/database_health_check.py
+++ b/server/app/routes/database_health_check.py
@@ -1,14 +1,14 @@
 from flask import Blueprint, jsonify
 from app.services.handle_db_connections import create_conn
+import pymysql
 
 bp = Blueprint("health", __name__)
 
-# health check endpoint
 @bp.get("/health")
 def health():
     try:
         connection = create_conn()
-        with connection.cursor() as cur:
+        with connection.cursor(pymysql.cursors.DictCursor) as cur:
             cur.execute("SELECT 1 as ok;")
             row = cur.fetchone()
         connection.close()


### PR DESCRIPTION
Fix #60: Backend  connection uses DictCursor to prevent index error

Backend & frontend Docker stack now run successfully